### PR TITLE
Support attrs _InValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-====================
-jsonschema-extractor
-====================
+=============================
+jsonschema-extractor-extended
+=============================
+
+This package is an extension of [jsonschema-extractor](https://github.com/toumorokoshi/jsonschema-extractor).
+Bellow you can see the original documentation of the package.
 
 jsonschema-extractor is a library and extensible framework for
 extracting `json schema <http://json-schema.org/>`_ from various object and

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
-=============================
-jsonschema-extractor-extended
-=============================
-
-This package is an extension of [jsonschema-extractor](https://github.com/toumorokoshi/jsonschema-extractor).
-Bellow you can see the original documentation of the package.
+====================
+jsonschema-extractor
+====================
 
 jsonschema-extractor is a library and extensible framework for
 extracting `json schema <http://json-schema.org/>`_ from various object and

--- a/jsonschema_extractor/__init__.py
+++ b/jsonschema_extractor/__init__.py
@@ -1,17 +1,21 @@
 from .extractor_set import SchemaExtractorSet
 
 from .typing_extractor import TypingExtractor
+
 DEFAULT_EXTRACTOR_LIST = [
     TypingExtractor()
 ]
 try:
     from .attrs_extractor import AttrsExtractor
+
     DEFAULT_EXTRACTOR_LIST.insert(0, AttrsExtractor())
-except ImportError: # pragma: no cover
-    pass # pragma: no cover
+except ImportError:  # pragma: no cover
+    pass  # pragma: no cover
+
 
 def extract_jsonschema(typ):
     return DEFAULT_EXTRACTOR.extract(typ)
+
 
 def init_default_extractor():
     """
@@ -20,8 +24,10 @@ def init_default_extractor():
     """
     return SchemaExtractorSet(DEFAULT_EXTRACTOR_LIST)
 
+
 DEFAULT_EXTRACTOR = init_default_extractor()
 from .exceptions import UnextractableSchema
+
 
 def extract(cls):
     return DEFAULT_EXTRACTOR.extract(cls)

--- a/jsonschema_extractor/__init__.py
+++ b/jsonschema_extractor/__init__.py
@@ -1,21 +1,17 @@
 from .extractor_set import SchemaExtractorSet
 
 from .typing_extractor import TypingExtractor
-
 DEFAULT_EXTRACTOR_LIST = [
     TypingExtractor()
 ]
 try:
     from .attrs_extractor import AttrsExtractor
-
     DEFAULT_EXTRACTOR_LIST.insert(0, AttrsExtractor())
-except ImportError:  # pragma: no cover
-    pass  # pragma: no cover
-
+except ImportError: # pragma: no cover
+    pass # pragma: no cover
 
 def extract_jsonschema(typ):
     return DEFAULT_EXTRACTOR.extract(typ)
-
 
 def init_default_extractor():
     """
@@ -24,10 +20,8 @@ def init_default_extractor():
     """
     return SchemaExtractorSet(DEFAULT_EXTRACTOR_LIST)
 
-
 DEFAULT_EXTRACTOR = init_default_extractor()
 from .exceptions import UnextractableSchema
-
 
 def extract(cls):
     return DEFAULT_EXTRACTOR.extract(cls)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if "--release" in sys.argv:
 
 base = os.path.dirname(os.path.abspath(__file__))
 
-README_PATH = os.path.join(base, "README.md")
+README_PATH = os.path.join(base, "README.rst")
 
 install_requires = []
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if "--release" in sys.argv:
 
 base = os.path.dirname(os.path.abspath(__file__))
 
-README_PATH = os.path.join(base, "README.rst")
+README_PATH = os.path.join(base, "README.md")
 
 install_requires = []
 


### PR DESCRIPTION
## Support attrs in validator.
The extractor will extract the `options` attribute from the validator and inject its value into the schema under the `enum` keyword.  
Currently the extractor supports any attribute with the `_InValidator` defined, even if it doesn't have an explicit type.

I added two test cases, if you think there should be more I would love to add them, just say which tests are missing :)

Thanks for the great library :heart: 