### PR TITLE
fix typing extractor not handling IntEnum handler

### DIFF
--- a/jsonschema_extractor/tests/test_typing.py
+++ b/jsonschema_extractor/tests/test_typing.py
@@ -93,3 +93,23 @@ def test_typing_extractor_nontype(extractor):
     Users may want to have a custom type annotation.
     """
     assert extractor.extract(object()) == {"type": "object"}
+
+
+def test_typing_extractor_int_enum(typing_extractor):
+    """A custom extractor for an IntEnum should match.
+
+    This tests case catches an issue where an IntEnum was
+    matched with the integer extractor, despite a custom type
+    being matched to it. (GitHub #9)
+    """
+    from enum import IntEnum
+
+    class Test(IntEnum):
+        A = 1
+        B = 2
+        C = 3
+
+    typing_extractor.register(
+        IntEnum, lambda extractor, typ: {"enum": [c.name for c in typ]}
+    )
+    assert typing_extractor.extract(None, Test) == {"enum": ["A", "B", "C"]}


### PR DESCRIPTION
Addresses GitHub #9.

Adding a custom handler for IntEnum in TypingExtractor
resulted in the int handler still being used, due to the
handler resolver logic iterating through a list and checking
for matches via seeing if the passed type is a subclass, rather than
looking for the most granular match to the type it can.

Refactoring the logic to iterate the mro and find a match, which
means it'll check for the most granular match first.