### PR TITLE
fix attrs incorrect types with future annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,6 @@ lint-check: .venv/deps
 	.venv/bin/python -m black --check .
 
 test: .venv/deps
-	.venv/bin/python -m pytest jsonschema_extractor
+	.venv/bin/python -m pytest jsonschema_extractor -vv
 
 ready-pr: test lint

--- a/jsonschema_extractor/attrs_extractor.py
+++ b/jsonschema_extractor/attrs_extractor.py
@@ -17,6 +17,10 @@ class AttrsExtractor(object):
         take an attrs based class, and convert it
         to jsonschema.
         """
+        # for those importing __annotations__ from future,
+        # resolve the types.
+        if hasattr(attr, "resolve_types"):
+            attr.resolve_types(typ)
         schema = {
             "title": typ.__name__,
             "type": "object",

--- a/jsonschema_extractor/tests/test_attrs_future_annotations.py
+++ b/jsonschema_extractor/tests/test_attrs_future_annotations.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+# similar to test_attrs, but specifically testing
+# future imports.
+from typing import List
+
+import attr
+from attr.validators import instance_of
+
+from jsonschema_extractor import UnextractableSchema
+
+
+@attr.define
+class Example(object):
+    integer: int = attr.field()
+    foo = attr.field(metadata={"jsonschema": {"type": "string", "format": "uuid"}})
+    validator_list: List[float] = attr.field()
+    floating_point: float = attr.field(validator=instance_of(float))
+    string: str = attr.field(
+        default="foo", metadata={"description": "This is an description."}
+    )
+
+
+def test_extract_attrs(extractor):
+    assert extractor.extract(Example) == {
+        "type": "object",
+        "title": "Example",
+        "properties": {
+            "floating_point": {"type": "number"},
+            "string": {"description": "This is an description.", "type": "string"},
+            "integer": {"type": "integer"},
+            "validator_list": {"items": {"type": "number"}, "type": "array"},
+            "foo": {"type": "string", "format": "uuid"},
+        },
+        "required": ["integer", "foo", "validator_list", "floating_point"],
+    }


### PR DESCRIPTION
__future__ annotations breaks schema extraction for attrs

This sets an implicit dependency on attrs to be greater than 20.1.0. (https://www.attrs.org/en/stable/changelog.html#id82)

fixes #13.